### PR TITLE
test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM docker:19.03.4
 
+RUN apk update \
+  && apk upgrade \
+  && apk add --no-cache --update coreutils bash \
+  && rm -rf /var/cache/apk/*
+
 ADD entrypoint.sh /entrypoint.sh
 
 RUN ["chmod", "+x", "/entrypoint.sh"]


### PR DESCRIPTION
GitHub sets `$INPUT_X` envvars for you based on the inputs set in your action.yml. If you provide default values in the action.yml and dont explicitly pass in an input in `with`, then the `$INPUT_X` envvar will get set to the default. If your action is a docker action, it's built first and then run, and when it's run, all of these $INPUT_X env vars get passed into the container as options like `-e $INPUT_X`. 

The problem: when your action uses a prebuilt image, i.e. `uses: docker://ghcr.io/codfish/docker-action-issue:latest`, any inputs that aren't explicitly sent in `with`, those input vars do NOT get passed into the docker container in the run command.

The following screenshot is both run commands. On the left is when your `uses` declaration points to a repo location, and GitHub has to build the image themselves. On the right is when you point to a prebuilt image.

<img width="999" alt="image" src="https://user-images.githubusercontent.com/1666298/114802775-41bf0a80-9d6c-11eb-8005-72ecfcc0584b.png">

Good one (Left): https://github.com/LeafLink/llf-web/pull/869/checks?check_run_id=2347949148#step:5:136
Bad one (Right): https://github.com/LeafLink/llf-web/pull/869/checks?check_run_id=2347949148#step:6:19